### PR TITLE
[9.0] deprecate reentrant calls to the statechart

### DIFF
--- a/statechart/models/statechart_mixin.py
+++ b/statechart/models/statechart_mixin.py
@@ -148,16 +148,6 @@ class StatechartMixin(models.AbstractModel):
 
         @api.multi
         def partial(self, *args, **kwargs):
-            if event_name == 'write':
-                # TODO remove this, we don't allow write as event
-                vals = args[0]
-                if 'sc_state' in vals:
-                    if len(vals) == 1:
-                        return self.write.origin(self, vals)
-                    else:
-                        raise UserError(_(
-                            "Cannot write sc_state together "
-                            "with other values."))
             return self._sc_exec_event(event_name, *args, **kwargs)
         try:
             m = getattr(cls, event_name)

--- a/statechart_demo_purchase/demo/statechart.xml
+++ b/statechart_demo_purchase/demo/statechart.xml
@@ -25,16 +25,8 @@ statechart:
       - event: unlink
         # unlink test
         action: |
-          # writing o.state would fail because, since there is a write
-          # event, the call to write ends up being enqueued, and therefore
-          # being executed after the actual unlink; so we write
-          # the call unlink again, which will itself be enqueued and
-          # only call the original unlink when the state is correct.
-          if o.state != 'cancel':
-              o.state = 'cancel'
-              o.unlink()
-          else:
-              o.unlink.origin(o)
+          o.state = 'cancel'
+          o.unlink.origin(o)
       - event: raise_user_error
         action: |
           o.raise_user_error.origin(o)
@@ -49,19 +41,14 @@ statechart:
             action: |
               # TODO this is not a very nice way to invoke the origin method
               o.button_confirm.origin(o, *event.args, **event.kwargs)
-          - event: write
-            action: |
-              # we can even have the write method go through the statechart
-              o.write.origin(o, event.args[0])
+          - event: check_write
       - name: not draft
         transitions:
-          - event: write
+          - event: check_write
             guard: |
               # and put some guard on the write methods, eg to
               # allow writeing selected fields only depending on state
               not (set(event.args[0].keys()) - set(['state', 'sc_state', 'notes', 'group_id']))
-            action: |
-              o.write.origin(o, event.args[0])
         states:
           - name: confirmed
             transitions:

--- a/statechart_demo_purchase/models/purchase_order.py
+++ b/statechart_demo_purchase/models/purchase_order.py
@@ -13,3 +13,8 @@ class PurchaseOrder(models.Model):
 
     def raise_user_error(self):
         raise UserError(_("Some error"))
+
+    def write(self, vals):
+        if not vals.get('sc_state'):
+            self.sc_queue('check_write', vals)
+        return super(PurchaseOrder, self).write(vals)

--- a/statechart_demo_purchase/tests/test_po_statechart.py
+++ b/statechart_demo_purchase/tests/test_po_statechart.py
@@ -110,15 +110,9 @@ class TestPOStatechart(common.TransactionCase):
         self.assertScState(self.po.sc_state,
                            ["approved", "not draft", "root"])
         self.assertEqual(self.po.state, 'purchase')
-        # TODO this test is currently failing because _compute_sc_interpreter
-        #      create a new interpreter instance while another one is already
-        #      executing for the same record... need to find something better
-        #      than a computed field to manage the lifecycle of interpreter
-        #      instances
-        if False:  # pylint: disable=using-constant-test
-            self.assertEqual(self.po.notes,
-                             'Congrats for entering the approved state')
-            self.assertFalse(self.po.sc_button_approve_allowed)
+        self.assertEqual(self.po.notes,
+                         'Congrats for entering the approved state')
+        self.assertFalse(self.po.sc_button_approve_allowed)
 
     def test_no_write(self):
         self.po.button_confirm()


### PR DESCRIPTION
When a transition action calls methods that are mapped to statechart event, they are enqueued instead of being executed synchronously.

This may lead to very surprising code, since there is no cue in the calling code that such queuing is taking place.

So we log an error in such situation, as a deprecation measure, and encourage the developer to call `sc_queue(event_name, *args)` instead.

@ThomasBinsfeld @lmignon @zmakrelouf