### PR TITLE
[14.0] [FIX] statechart_mixin: sc_state must be readonly

### DIFF
--- a/statechart/models/statechart_mixin.py
+++ b/statechart/models/statechart_mixin.py
@@ -53,6 +53,7 @@ class StatechartMixin(models.AbstractModel):
 
     sc_state = fields.Char(
         copy=False,
+        readonly=True,
     )
     sc_interpreter = InterpreterField(
         compute='_compute_sc_interpreter')


### PR DESCRIPTION
By making the sc_state field readonly we forbid unwanted transitions via import or xmlrpc calls

Forward port of https://github.com/acsone/scobidoo/pull/33