### PR TITLE
[13.0] [IMP] Statechart interpreter: print execution traceback

### DIFF
--- a/statechart/models/interpreter.py
+++ b/statechart/models/interpreter.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import sys
+import traceback
 
 from sismic.exceptions import CodeEvaluationError
 from sismic.interpreter import Interpreter as SismicInterpreter
@@ -43,6 +44,7 @@ class Interpreter(SismicInterpreter):
             try:
                 return super(Interpreter, self).execute_once()
             except CodeEvaluationError as e:
+                traceback.print_exc()
                 raise _root_cause(e).with_traceback(sys.exc_info()[2])
         finally:
             self._in_execute_once = False

--- a/statechart/models/interpreter.py
+++ b/statechart/models/interpreter.py
@@ -8,6 +8,7 @@ from sismic.exceptions import CodeEvaluationError
 from sismic.interpreter import Interpreter as SismicInterpreter
 from sismic.model import Event
 from odoo.exceptions import except_orm
+from odoo import tools
 
 
 def _root_cause(e):
@@ -44,7 +45,8 @@ class Interpreter(SismicInterpreter):
             try:
                 return super(Interpreter, self).execute_once()
             except CodeEvaluationError as e:
-                traceback.print_exc()
+                if not tools.config["test_enable"]:
+                    traceback.print_exc()
                 raise _root_cause(e).with_traceback(sys.exc_info()[2])
         finally:
             self._in_execute_once = False


### PR DESCRIPTION
In some cases, statechart hide the root traceback of an error, making it very difficult to debug.

The raise statement `raise _root_cause(e).with_traceback(sys.exc_info()[2])` may be improved but `raise _root_cause(e)` is not a good solution.

While waiting for a better solution that would allow to raise an error with the complete traceback, let's print additionnal information with `traceback.print_exc()`. We're now sure to have everything needed for debug.