### PR TITLE
[14.0][IMP] stachechart_mixin: make it possible to ignore some events in the has_allowed_event compute

### DIFF
--- a/statechart/models/statechart_mixin.py
+++ b/statechart/models/statechart_mixin.py
@@ -315,9 +315,14 @@ class StatechartMixin(models.AbstractModel):
 
     @api.model
     def _get_sc_event_allowed_field_names(self):
+        ignore_for_has_allowed_events = self.env.context.get(
+            "ignore_for_has_allowed_events", []
+        )
         event_names = self._statechart.events_for()
         return [
-            _sc_make_event_allowed_field_name(event_name) for event_name in event_names
+            _sc_make_event_allowed_field_name(event_name)
+            for event_name in event_names
+            if event_name not in ignore_for_has_allowed_events
         ]
 
     @api.depends("sc_state")

--- a/statechart/models/statechart_mixin.py
+++ b/statechart/models/statechart_mixin.py
@@ -314,20 +314,16 @@ class StatechartMixin(models.AbstractModel):
         return res
 
     @api.model
-    def _get_sc_event_allowed_field_names(self):
-        ignore_for_has_allowed_events = self.env.context.get(
-            "ignore_for_has_allowed_events", []
-        )
-        event_names = self._statechart.events_for()
+    def _get_sc_event_allowed_field_names(self, events_to_ignore=None):
+        event_names = set(self._statechart.events_for()) - set(events_to_ignore or [])
         return [
-            _sc_make_event_allowed_field_name(event_name)
-            for event_name in event_names
-            if event_name not in ignore_for_has_allowed_events
+            _sc_make_event_allowed_field_name(event_name) for event_name in event_names
         ]
 
     @api.depends("sc_state")
     def _compute_sc_has_allowed_events(self):
-        sc_fields = self._get_sc_event_allowed_field_names()
+        events_to_ignore = self.env.context.get("ignore_for_has_allowed_events")
+        sc_fields = self._get_sc_event_allowed_field_names(events_to_ignore)
         for rec in self:
             rec.sc_has_allowed_events = any([rec[f] for f in sc_fields])
 

--- a/test_statechart/models/test_statechart.yml
+++ b/test_statechart/models/test_statechart.yml
@@ -8,10 +8,18 @@ statechart:
         transitions:
           - event: confirm1
             target: confirmed1
+          - target: canceled
+            event: cancel
       - name: confirmed1
         transitions:
           - target: confirmed2
             guard: o.amount < 100
           - target: confirmed2
             event: confirm2
+          - target: canceled
+            event: cancel
       - name: confirmed2
+        transitions:
+          - target: canceled
+            event: cancel
+      - name: canceled

--- a/test_statechart/tests/test_basic.py
+++ b/test_statechart/tests/test_basic.py
@@ -37,3 +37,34 @@ class TestBasic(common.TransactionCase):
         record.confirm1()
         # small amount, step 2 done automatically
         self.assertScState(record.sc_state, ["confirmed2", "root"])
+
+    def test_get_sc_event_allowed_field_names(self):
+        """
+        Test that we can ignore certain events based on a context
+        key (ignore_for_has_allowed_events)
+        """
+        model = self.env["scobidoo.test.model"]
+        record = model.create({"amount": 200})
+        record.confirm1()
+        self.assertScState(record.sc_state, ["confirmed1", "root"])
+
+        # 2 events are allowed: confirmed2 and cancel
+        self.assertEqual(record.sc_has_allowed_events, True)
+
+        # 1 event is allowed: confirmed2
+        record.invalidate_cache()
+        self.assertEqual(
+            record.with_context(
+                ignore_for_has_allowed_events=["cancel"]
+            ).sc_has_allowed_events,
+            True,
+        )
+
+        # no event allowed
+        record.invalidate_cache()
+        self.assertEqual(
+            record.with_context(
+                ignore_for_has_allowed_events=["cancel", "confirm2"]
+            ).sc_has_allowed_events,
+            False,
+        )

--- a/test_statechart/tests/test_basic.py
+++ b/test_statechart/tests/test_basic.py
@@ -38,7 +38,7 @@ class TestBasic(common.TransactionCase):
         # small amount, step 2 done automatically
         self.assertScState(record.sc_state, ["confirmed2", "root"])
 
-    def test_get_sc_event_allowed_field_names(self):
+    def test_get_sc_sc_has_allowed_events(self):
         """
         Test that we can ignore certain events based on a context
         key (ignore_for_has_allowed_events)


### PR DESCRIPTION
This commits makes it possible to ignore some events when computing has_allowed_events by passing them in the context key `ignore_for_has_allowed_events`.
For example, our record has a cancel action on each state but we don't want to take that action into account when getting the records with allowed_events
Our use case is showing all the records that need an action in a dashboard. But the records with a cancel action are not actually in need of an action.