### PR TITLE
[CHG] display error pop up instead of stacktrace when raising a TransitionError

### DIFF
--- a/statechart/__manifest__.py
+++ b/statechart/__manifest__.py
@@ -19,5 +19,10 @@
     },
     "data": [],
     "demo": [],
+    "assets": {
+        "web.assets_backend": [
+            "statechart/static/src/core/errors/error_dialogs.esm.js",
+        ],
+    },
     "installable": True,
 }

--- a/statechart/static/src/core/errors/error_dialogs.esm.js
+++ b/statechart/static/src/core/errors/error_dialogs.esm.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import {_lt} from "@web/core/l10n/translation";
+import {registry} from "@web/core/registry";
+
+import {WarningDialog, odooExceptionTitleMap} from "@web/core/errors/error_dialogs";
+
+registry
+    .category("error_dialogs")
+    .add("odoo.addons.statechart.exceptions.NoTransitionError", WarningDialog);
+
+odooExceptionTitleMap["odoo.addons.statechart.exceptions.NoTransitionError"] =
+    _lt("Transition Error");


### PR DESCRIPTION
Before this PR, the stacktrace was shown when a TransitionError was raised. This PR changes this behavior to use the WarningDialog.