### PR TITLE
[18.0][FIX] statechart: Avoid useless noise into logs when running tests

### DIFF
--- a/statechart/models/statechart_mixin.py
+++ b/statechart/models/statechart_mixin.py
@@ -4,7 +4,7 @@
 import json
 import logging
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import MissingError, UserError
 
 from ..exceptions import NoTransitionError
@@ -288,6 +288,7 @@ class StatechartMixin(models.AbstractModel):
                 self._sc_make_event_allowed_field(def_cls, event_name)
         return super()._setup_base()
 
+    @tools.mute_logger("odoo.tests.common")
     @api.model
     def _sc_patch(self):
         cls = type(self)


### PR DESCRIPTION
This is required to avoid to have test logs polluted with warning like
```
2026-03-27 10:50:05,811 106 INFO odoo-brubox-2177489 odoo.tests.common: /odoo/lib/python3.12/site-packages/odoo/addons/statechart/models/statechart_mixin.py:312:_sc_patch setting brb.claim._statechart to Statechart('brb.claim') 
Stack (most recent call last):
  File "/odoo/bin/coverage", line 6, in <module>
    sys.exit(main())
  File "/odoo/lib/python3.12/site-packages/coverage/cmdline.py", line 970, in main
    status = CoverageScript().command_line(argv)
  File "/odoo/lib/python3.12/site-packages/coverage/cmdline.py", line 681, in command_line
    return self.do_run(options, args)
  File "/odoo/lib/python3.12/site-packages/coverage/cmdline.py", line 858, in do_run
    runner.run()
  File "/odoo/lib/python3.12/site-packages/coverage/execfile.py", line 208, in run
    exec(code, main_mod.__dict__)
  File "/odoo/bin/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/lib/python3.12/site-packages/odoo/cli/command.py", line 76, in main
    o.run(args)
  File "/odoo/lib/python3.12/site-packages/odoo/cli/server.py", line 182, in run
    main(args)
  File "/odoo/lib/python3.12/site-packages/odoo/cli/server.py", line 175, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/lib/python3.12/site-packages/odoo/service/server.py", line 1462, in start
    rc = server.run(preload, stop)
  File "/odoo/lib/python3.12/site-packages/odoo/service/server.py", line 627, in run
    rc = preload_registries(preload)
  File "/odoo/lib/python3.12/site-packages/odoo/service/server.py", line 1393, in preload_registries
    result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
  File "/odoo/lib/python3.12/site-packages/odoo/tests/loader.py", line 118, in run_suite
    suite(results)
  File "/usr/lib/python3.12/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/odoo/lib/python3.12/site-packages/odoo/tests/suite.py", line 42, in run
    self._tearDownPreviousClass(test, result)
  File "/odoo/lib/python3.12/site-packages/odoo/tests/suite.py", line 190, in _tearDownPreviousClass
    super()._tearDownPreviousClass(test, result)
  File "/odoo/lib/python3.12/site-packages/odoo/tests/suite.py", line 112, in _tearDownPreviousClass
    previousClass.doClassCleanups()
  File "/odoo/lib/python3.12/site-packages/odoo/tests/case.py", line 247, in doClassCleanups
    function(*args, **kwargs)
  File "/odoo/lib/python3.12/site-packages/odoo/tests/common.py", line 1004, in reset_changes
    cls.registry.setup_models(cr)
  File "/odoo/lib/python3.12/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/lib/python3.12/site-packages/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/lib/python3.12/site-packages/odoo/modules/registry.py", line 359, in setup_models
    model._setup_complete()
  File "/odoo/lib/python3.12/site-packages/odoo/addons/statechart/models/statechart_mixin.py", line 329, in _setup_complete
    self._sc_patch()
  File "/odoo/lib/python3.12/site-packages/odoo/addons/statechart/models/statechart_mixin.py", line 312, in _sc_patch
    cls._statechart = statechart
  File "/odoo/lib/python3.12/site-packages/odoo/tests/common.py", line 986, in metamodel_setattr
    _logger.runbot(
  File "/odoo/lib/python3.12/site-packages/odoo/netsvc.py", line 360, in runbot
    self.log(logging.RUNBOT, message, *args, **kws)
```